### PR TITLE
Use uharfbuzz to extract glyph shapes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ lightning = "2.0.6"
 wandb = "0.15.8"
 fs = "2.4.16"
 gradio = "3.42.0"
+uharfbuzz = "0.37.3"
 
 [dev-packages]
 


### PR DESCRIPTION
This uses uharfbuzz instead of fontTools to extract the glyph outlines. You'll want to do this for two reasons:

1) It's really fast.
2) It gives you easy access to setting variations, and getting outlines with OT variations applied.

This second point means that you can easily create a large number of "fonts" from a single variable font. I've decided to use normalised variation coords (-1..1 for each axis) since it's easier to generate these than to have to grovel through the fvar table for the appropriate user-space range.